### PR TITLE
Work arounds for empty variables

### DIFF
--- a/chtf/chtf.fish
+++ b/chtf/chtf.fish
@@ -19,8 +19,9 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-set CHTF_VERSION (string split "=" (head -1 (dirname (status --current-filename))/version.env))[2]
-test -n "$CASKROOM"; or set CASKROOM '/usr/local/Caskroom'
+set VERSION_FILE (cd (dirname (status -f)); and pwd)/version.env
+set -g CHTF_VERSION (string split "=" (head -1 $VERSION_FILE))[2]
+test -n "$CASKROOM"; or set -g CASKROOM '/usr/local/Caskroom'
 
 function chtf_reset
     if test -z $CHTF_CURRENT

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -21,7 +21,7 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # load version
-source $(dirname $BASH_SOURCE)/version.env
+source $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/version.env
 : ${CASKROOM:=/usr/local/Caskroom}
 
 chtf_reset() {


### PR DESCRIPTION
Variables were not being passed into functions w/o passing -g for me. Also a two liner for getting CHTF_VERSION to avoid that long one liner. Just personal preference but thought It's throw it in there. 